### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/vishalnakum/88918b4c-f254-4e10-8a73-e79863578103/1725b187-073c-4236-ae7e-af1dccd82ae4/_apis/work/boardbadge/6c80ba3c-4180-4fdd-b46c-58a544284e6f)](https://dev.azure.com/vishalnakum/88918b4c-f254-4e10-8a73-e79863578103/_boards/board/t/1725b187-073c-4236-ae7e-af1dccd82ae4/Microsoft.RequirementCategory)
 
 # Contributing
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#8](https://dev.azure.com/vishalnakum/88918b4c-f254-4e10-8a73-e79863578103/_workitems/edit/8). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.